### PR TITLE
A button

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,12 +1,16 @@
 import 'react-app-polyfill/ie11';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Thing } from '../.';
+import { Button, OntwikProvider } from '../.';
 
 const App = () => {
   return (
     <div>
-      <Thing />
+      <OntwikProvider>
+        <Button type="button" variant="primary" size="large">
+          Test
+        </Button>
+      </OntwikProvider>
     </div>
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.0.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -35,7 +35,7 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "name": "ui",
+  "name": "ontwik-ui",
   "author": "smakosh",
   "module": "dist/ui.esm.js",
   "size-limit": [
@@ -71,5 +71,23 @@
   },
   "dependencies": {
     "styled-components": "^5.2.0"
-  }
+  },
+  "description": "A headless UI library.",
+  "directories": {
+    "example": "example",
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Ontwik-Dev/ontwik-ui.git"
+  },
+  "keywords": [
+    "components",
+    "theme",
+    "headless"
+  ],
+  "bugs": {
+    "url": "https://github.com/Ontwik-Dev/ontwik-ui/issues"
+  },
+  "homepage": "https://github.com/Ontwik-Dev/ontwik-ui#readme"
 }

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   "size-limit": [
     {
       "path": "dist/ui.cjs.production.min.js",
-      "limit": "10 KB"
+      "limit": "20 KB"
     },
     {
       "path": "dist/ui.esm.js",
-      "limit": "10 KB"
+      "limit": "20 KB"
     }
   ],
   "devDependencies": {

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -3,17 +3,30 @@ import { ButtonProps } from '../../interfaces';
 
 const Button = styled.button<ButtonProps>`
   text-decoration: none;
-  border-radius: 0.3rem;
   cursor: pointer;
-  font-size: 12pt;
-	transition: 0.3s;
-	color: ${({ color }) => color || '#000'};
+  transition: 0.3s;
+  border-radius: ${({
+    theme: {
+      buttons: {
+        default: { borderRadius },
+      },
+    },
+  }) => borderRadius};
+  font-size: ${({
+    theme: {
+      buttons: {
+        default: { fontSize },
+      },
+    },
+  }) => fontSize};
 
   &:hover {
     transition: 0.3s;
-	}
-	
-	${({ uppercase }) => uppercase && `
+  }
+
+  ${({ uppercase }) =>
+    uppercase &&
+    `
 		text-transform: uppercase;
 	`}
 
@@ -31,63 +44,38 @@ const Button = styled.button<ButtonProps>`
     borderColor,
     color,
     theme: {
-      colors: { primary, white, stateColors },
+      buttons: { primary, secondary, ghost },
     },
   }) => {
     switch (variant) {
-      case 'ghost':
-        return `
-          color: ${state ? stateColors[state] : color};
-					background: none;
-					border: none;
-				`;
       case 'primary':
-        return `
-					color: ${white};
-					background: ${state ? stateColors[state] : (bg || primary[900])};
-					border: 1px solid transparent;
-
-					&:hover {
-						background: ${state ? stateColors[state] : (bg || primary[700])};
-					}
-				`;
+        return primary({ state, bg });
       case 'secondary':
-        return `
-					color: ${state ? stateColors[state] : (borderColor || primary[900])};
-					background: ${white};
-					border: ${state ? stateColors[state] : (borderColor || primary[900])} 1px solid;
-
-					&:hover {
-						background: ${state ? stateColors[state] : (borderColor || primary[900])};
-						color: ${white};
-						border-color: ${state ? stateColors[state] : (borderColor || primary[900])} 1px solid;
-					}
-				`;
+        return secondary({ state, borderColor });
+      case 'ghost':
+        return ghost({ state, color });
       default:
         return null;
     }
   }}
 
-  ${({ size }) => {
+  ${({
+    size,
+    theme: {
+      buttons: {
+        sizes: { xlarge, large, medium, small },
+      },
+    },
+  }) => {
     switch (size) {
       case 'xlarge':
-        return `
-					padding: 1rem 2rem;
-				`;
+        return xlarge();
       case 'large':
-        return `
-					padding: 0.7rem 2rem;
-				`;
+        return large();
       case 'medium':
-        return `
-          padding: 0.4rem 1.8rem;
-          font-size: 10pt;
-        `;
+        return medium();
       case 'small':
-        return `
-          padding: 0.3rem 1.6rem;
-          font-size: 8pt;
-        `;
+        return small();
       default:
         return null;
     }

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -2,68 +2,65 @@ import styled from 'styled-components';
 import { ButtonProps } from '../../interfaces';
 
 const Button = styled.button<ButtonProps>`
-	text-decoration: none;
-	text-transform: uppercase;
-	border-radius: 0.3rem;
-	cursor: pointer;
-	font-size: 12pt;
+  text-decoration: none;
+  border-radius: 0.3rem;
+  cursor: pointer;
+  font-size: 12pt;
 	transition: 0.3s;
+	color: ${({ color }) => color || '#000'};
 
-	&:hover {
-		transition: 0.3s;
+  &:hover {
+    transition: 0.3s;
 	}
+	
+	${({ uppercase }) => uppercase && `
+		text-transform: uppercase;
+	`}
 
-	${({ wide }) =>
+  ${({ wide }) =>
     wide &&
     `
       width: 100%;
       text-align: center;
 	`}
 
-	${({
+  ${({
     variant,
     state,
+    bg,
+    borderColor,
+    color,
     theme: {
-      colors: { primary, secondary, white, stateColors },
+      colors: { primary, white, stateColors },
     },
   }) => {
     switch (variant) {
-      case 'blank':
+      case 'ghost':
         return `
+          color: ${state ? stateColors[state] : color};
 					background: none;
 					border: none;
-					color: ${stateColors['danger']};
-				`;
-      case 'cta':
-        return `
-					color: ${white};
-					background: ${state ? stateColors[state] : secondary[900]};
-					border: 1px solid transparent;
-
-					&:hover {
-						background: ${state ? stateColors[state] : secondary[700]};
-					}
 				`;
       case 'primary':
         return `
 					color: ${white};
-					background: ${state ? stateColors[state] : primary[900]};
+					background: ${state ? stateColors[state] : (bg || primary[900])};
 					border: 1px solid transparent;
 
 					&:hover {
-						background: ${state ? stateColors[state] : primary[700]};
+						background: ${state ? stateColors[state] : (bg || primary[700])};
 					}
 				`;
       case 'secondary':
         return `
-					color: ${state ? stateColors[state] : primary[900]};
+					color: ${state ? stateColors[state] : (borderColor || primary[900])};
 					background: ${white};
-					border: ${state ? stateColors[state] : primary[900]} 1px solid;
+					border: ${state ? stateColors[state] : (borderColor || primary[900])} 1px solid;
 
 					&:hover {
-						background: ${state ? stateColors[state] : primary[900]};
+						background: ${state ? stateColors[state] : (borderColor || primary[900])};
 						color: ${white};
-						border-color: ${state ? stateColors[state] : primary[900]} 1px solid;
+						border-color: ${state ? stateColors[state] : (borderColor || primary[900])} 1px solid;
 					}
 				`;
       default:
@@ -71,7 +68,7 @@ const Button = styled.button<ButtonProps>`
     }
   }}
 
-	${({ size }) => {
+  ${({ size }) => {
     switch (size) {
       case 'xlarge':
         return `
@@ -83,23 +80,23 @@ const Button = styled.button<ButtonProps>`
 				`;
       case 'medium':
         return `
-						padding: 0.4rem 1.8rem;
-						font-size: 10pt;
-					`;
+          padding: 0.4rem 1.8rem;
+          font-size: 10pt;
+        `;
       case 'small':
         return `
-						padding: 0.3rem 1.6rem;
-						font-size: 8pt;
-					`;
+          padding: 0.3rem 1.6rem;
+          font-size: 8pt;
+        `;
       default:
         return null;
     }
   }}
-	
-	&:disabled {
-		background-color: ${({ theme }) => theme.colors.black[200]};
-		color: ${({ theme }) => theme.colors.black[700]};
-	}
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.black[200]};
+    color: ${({ theme }) => theme.colors.black[700]};
+  }
 `;
 
 export default Button;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -17,3 +17,10 @@ export interface InputFieldProps {
   error?: string | boolean;
   relative?: boolean;
 }
+
+export interface StateAndColor {
+  state?: 'danger' | 'success' | 'warning';
+  color?: string;
+  bg?: string;
+  borderColor?: string;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,6 +5,10 @@ export interface ButtonProps {
   variant?: string;
   state?: string;
   size?: string;
+  uppercase?: boolean;
+  bg?: string;
+  color?: string;
+  borderColor?: string;
 }
 
 export interface InputFieldProps {

--- a/src/theme/buttons/index.ts
+++ b/src/theme/buttons/index.ts
@@ -1,0 +1,52 @@
+import colors from '../colors';
+import { StateAndColor } from '../../interfaces';
+
+export default {
+  default: {
+    fontSize: '12pt',
+    borderRadius: '0.3rem',
+  },
+  primary: ({ state, bg }: StateAndColor) => `
+    color: ${colors.white};
+    background: ${
+      state ? colors.stateColors[state] : bg || colors.primary[900]
+    };
+    border: 1px solid transparent;
+
+    &:hover {
+      background: ${
+        state ? colors.stateColors[state] : bg || colors.primary[700]
+      };
+    }
+  `,
+  secondary: ({ state, borderColor }: StateAndColor) => `
+    color: ${
+      state ? colors.stateColors[state] : borderColor || colors.primary[900]
+    };
+    background: ${colors.white};
+    border: ${
+      state ? colors.stateColors[state] : borderColor || colors.primary[900]
+    } 1px solid;
+
+    &:hover {
+      background: ${
+        state ? colors.stateColors[state] : borderColor || colors.primary[900]
+      };
+      color: ${colors.white};
+      border-color: ${
+        state ? colors.stateColors[state] : borderColor || colors.primary[900]
+      } 1px solid;
+    }
+  `,
+  ghost: ({ state, color }: StateAndColor) => `
+    color: ${state ? colors.stateColors[state] : color};
+    background: none;
+    border: none;
+  `,
+  sizes: {
+    xlarge: () => `padding: 1rem 2rem;`,
+    large: () => `padding: 0.7rem 2rem;`,
+    medium: () => `padding: 0.4rem 1.8rem; font-size: 10pt;`,
+    small: () => `padding: 0.3rem 1.6rem; font-size: 8pt;`,
+  },
+};

--- a/src/theme/colors/index.ts
+++ b/src/theme/colors/index.ts
@@ -1,0 +1,25 @@
+export default {
+  primary: {
+    700: '#7EA2A0',
+    900: '#007974',
+  },
+  secondary: {
+    700: '#5098EB',
+    900: '#1D7EEF',
+  },
+  black: {
+    200: '#bbb',
+    400: '#8D8A8A',
+    700: '#585858',
+    900: '#000',
+  },
+  red: {
+    200: '#F88383',
+  },
+  white: '#fff',
+  stateColors: {
+    danger: '#FF4B4B',
+    success: '#2ABF24',
+    warning: '#F89D33',
+  },
+};

--- a/src/theme/config.ts
+++ b/src/theme/config.ts
@@ -1,29 +1,9 @@
+import colors from './colors';
+import buttons from './buttons';
+
 const config = {
-  colors: {
-    primary: {
-      700: '#7EA2A0',
-      900: '#007974',
-    },
-    secondary: {
-      700: '#5098EB',
-      900: '#1D7EEF',
-    },
-    black: {
-      200: '#bbb',
-      400: '#8D8A8A',
-      700: '#585858',
-      900: '#000',
-    },
-    red: {
-      200: '#F88383',
-    },
-    white: '#fff',
-    stateColors: {
-      danger: '#FF4B4B',
-      success: '#2ABF24',
-      warning: '#F89D33',
-    },
-  },
+  colors,
+  buttons,
 };
 
 export default config;

--- a/stories/Button.stories.tsx
+++ b/stories/Button.stories.tsx
@@ -13,11 +13,11 @@ const meta: Meta = {
       description: 'Button variant',
       control: {
         type: 'select',
-        options: ['primary', 'secondary', 'cta', 'blank']
+        options: ['primary', 'secondary', 'ghost']
       }
     },
     size: {
-      name: 'Size',
+      name: 'size',
       type: { name: 'string', required: false },
       description: 'Button size',
       control: {
@@ -26,23 +26,65 @@ const meta: Meta = {
       }
     },
     state: {
-      name: 'State',
+      name: 'state',
       type: { name: 'string', required: false },
       description: 'Button state',
       control: {
-        type: 'inline-radio',
+        type: 'select',
         options: ['success', 'danger', 'warning', false]
       }
     },
     disabled: {
-      name: 'Disabled',
+      name: 'disabled',
       type: { name: 'boolean', required: false },
       description: 'Button disabled',
       control: {
         type: 'inline-radio',
         options: [true, false]
       }
-    }
+    },
+    wide: {
+      name: 'wide',
+      type: { name: 'boolean', required: false },
+      description: 'Button wide',
+      control: {
+        type: 'inline-radio',
+        options: [true, false ]
+      }
+    },
+    uppercase: {
+      name: 'uppercase',
+      type: { name: 'boolean', required: false },
+      description: 'Button text uppercase',
+      control: {
+        type: 'inline-radio',
+        options: [true, false ]
+      }
+    },
+    color: {
+      name: 'color',
+      type: { name: 'string', required: false },
+      description: 'Button text color',
+      control: {
+        type: 'color'
+      }
+    },
+    bg: {
+      name: 'bg',
+      type: { name: 'string', required: false },
+      description: 'Button background color',
+      control: {
+        type: 'color'
+      }
+    },
+    borderColor: {
+      name: 'borderColor',
+      type: { name: 'string', required: false },
+      description: 'Button border color',
+      control: {
+        type: 'color'
+      }
+    },
   },
   parameters: {
     controls: { expanded: true },


### PR DESCRIPTION
## What's new?
A button

### Variants
- primary
- secondary
- ghost

### Sizes
- xlarge
- large
- medium
- small
> uses padding with `rem` as the unit, comment below if you prefer using width/height rather than padding.

### States
- Success => green
- Warning => light orange
- error => red

## More utilities
- Disabled, defaults to `false`
- Uppercase, defaults to `false`
- Border color and text color for secondary button can be customized
- Background color for primary button can be customized
- Text color for ghost button can be customized

## Additional thoughts
- I'm thinking of letting you customize everything and moving this styling to the theme config to make it a fully headless button 🤔 